### PR TITLE
Fix 'coalesce.go:160: warning: skipped value for env: Not a table.'

### DIFF
--- a/charts/webhook-receiver/Chart.yaml
+++ b/charts/webhook-receiver/Chart.yaml
@@ -6,11 +6,11 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.8
+version: 1.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.7.0
+appVersion: 2.8.0
 sources:
     - https://github.com/adnanh/webhook
     - https://hub.docker.com/r/almir/webhook/
@@ -21,6 +21,6 @@ maintainers:
       url: https://hexf.me/
     - name: David Young
       email: davidy@funkypenguin.co.nz
-      url: https://www.funkypenguin.co.nz 
+      url: https://www.funkypenguin.co.nz
 
 home: https://geek-cookbook.funkypenguin.co.nz

--- a/charts/webhook-receiver/templates/configmap.yaml
+++ b/charts/webhook-receiver/templates/configmap.yaml
@@ -7,12 +7,12 @@ metadata:
 data:
   hooks.yaml: | {{- range $key, $val := .Values.hooks }}
     - {{ $val.hook | toYaml | indent 6 | trim }}
-  {{ end -}}
+  {{- end }}
   {{- range $key, $hook := .Values.hooks }}
     {{- range $name, $val := $hook.files }}
-      {{ if $hook.enable }}
+      {{- if $hook.enable }}
   file_{{ $name | replace "/" "_" | replace "%" "." }}: |
 {{ $val | indent 8 }}
-      {{ end }}
-    {{ end -}}
-  {{ end -}}
+      {{- end }}
+    {{- end }}
+  {{- end }}

--- a/charts/webhook-receiver/templates/deployment.yaml
+++ b/charts/webhook-receiver/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       imagePullSecrets:
-      - name: {{ .Values.imagePullSecret }}        
+      - name: {{ .Values.imagePullSecret }}
       containers:
         - name: {{ .Chart.Name }}
           args:
@@ -34,7 +34,7 @@ spec:
           {{- range $pkey, $pval := .Values.env }}
           - name: {{ $pkey }}
             value: {{ quote $pval }}
-          {{- end }}          
+          {{- end }}
           ports:
             - name: http
               containerPort: 9000
@@ -51,15 +51,15 @@ spec:
             - name: configs
               mountPath: "/etc/webhook/hooks.yaml"
               subPath: "hooks.yaml"
-          {{ range $key, $hook := .Values.hooks }}
-            {{ range $name, $val := $hook.files }}
-            {{ if $hook.enable }}
+          {{- range $key, $hook := .Values.hooks }}
+            {{- range $name, $val := $hook.files }}
+            {{- if $hook.enable }}
             - name: configs
               mountPath: {{ $name | replace "%" "." | quote }}
               subPath: "file_{{ $name | replace "/" "_" | replace "%" "." }}"
-            {{ end }}
-            {{ end }}
-          {{ end }}
+            {{- end }}
+            {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/charts/webhook-receiver/values.yaml
+++ b/charts/webhook-receiver/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: almir/webhook
-  tag: 2.7.0
+  tag: 2.8.0
   pullPolicy: IfNotPresent
 
 imagePullSecret: webhook-receiver-pullsecret
@@ -45,7 +45,7 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   hosts:
     - host: webhook-receiver.chart.local
-      paths: 
+      paths:
         - /
   tls: []
   #  - secretName: chart-example-tls

--- a/charts/webhook-receiver/values.yaml
+++ b/charts/webhook-receiver/values.yaml
@@ -71,7 +71,7 @@ tolerations: []
 affinity: {}
 
 # Use this to insert env values into the deployment
-env: []
+env: {}
 
 hooks:
   webhook1:


### PR DESCRIPTION
## Description
Each environment variable produces a helm warning when deploying: `coalesce.go:160: warning: skipped value for env: Not a table.` 

## Motivation and Context
This fixes the described warning.

On other hand, in another commit, I've updated the image used, it seems an innocuous change as the image does not change anything, it's just a new build, more info here: https://github.com/almir/docker-webhook/commit/2ba5698fa8bd4a3ac0c7977feb1fd1e7c4dbf427

Some cosmetic changes have been done in an another separated commit:

- Remove some empty lines in the resulting deployments & configmaps
- Remove trailing spaces in templates
 
## How Has This Been Tested?
I've done some deploys and they are working the same way but no warnings are produced

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I have read the [contribution guide](https://geek-cookbook.funkypenguin.co.nz/community/contribute/#contributing-recipes)
- [x] The format of my change matches that of existing code/documentation