### PR TITLE
Upgrade Ingress API version

### DIFF
--- a/charts/webhook-receiver/Chart.yaml
+++ b/charts/webhook-receiver/Chart.yaml
@@ -1,12 +1,12 @@
 apiVersion: v2
 name: webhook-receiver
-description: A Helm chart to recieve webhooks, and act accordingly.
+description: A Helm chart to receive webhooks, and act accordingly.
 
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.10
+version: 1.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/webhook-receiver/templates/deployment.yaml
+++ b/charts/webhook-receiver/templates/deployment.yaml
@@ -43,14 +43,14 @@ spec:
             - name: http
               containerPort: 9000
               protocol: TCP
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-            httpGet:
-              path: /hooks/status
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-            httpGet:
-              path: /hooks/status
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: configs
               mountPath: "/etc/webhook/hooks.yaml"

--- a/charts/webhook-receiver/templates/ingress.yaml
+++ b/charts/webhook-receiver/templates/ingress.yaml
@@ -1,11 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "webhook-receiver.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -16,6 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}
@@ -33,9 +30,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/webhook-receiver/values.yaml
+++ b/charts/webhook-receiver/values.yaml
@@ -44,6 +44,7 @@ service:
 
 ingress:
   enabled: true
+  ingressClassName: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
@@ -67,6 +68,15 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /hooks/status
+    port: http
+readinessProbe:
+  httpGet:
+    path: /hooks/status
+    port: http
 
 nodeSelector: {}
 


### PR DESCRIPTION
Probes are parametrizable

## Description
The Ingress definition is deprecated

## Motivation and Context
In order to upgrade our Kubernetes clusters we need to adapt the Ingress definition of this chart

## How Has This Been Tested?
Tested in our productive environment

## Types of changes
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] I have read the [contribution guide](https://geek-cookbook.funkypenguin.co.nz/community/contribute/#contributing-recipes)
- [X] The format of my change matches that of existing code/documentation