### PR TITLE
Allow to use different type of probes

### DIFF
--- a/charts/webhook-receiver/Chart.yaml
+++ b/charts/webhook-receiver/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.0
+version: 2.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/webhook-receiver/Chart.yaml
+++ b/charts/webhook-receiver/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.0
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/webhook-receiver/Chart.yaml
+++ b/charts/webhook-receiver/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.0
+version: 2.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/webhook-receiver/templates/deployment.yaml
+++ b/charts/webhook-receiver/templates/deployment.yaml
@@ -36,8 +36,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
           {{- range $pkey, $pval := .Values.env }}
-          - name: {{ $pkey }}
-            value: {{ quote $pval }}
+            - name: {{ $pkey }}
+              value: {{ quote $pval }}
           {{- end }}
           {{- with .Values.extraEnv }}
             {{- tpl . $ | nindent 12 }}

--- a/charts/webhook-receiver/templates/deployment.yaml
+++ b/charts/webhook-receiver/templates/deployment.yaml
@@ -39,6 +39,13 @@ spec:
           - name: {{ $pkey }}
             value: {{ quote $pval }}
           {{- end }}
+          {{- with .Values.extraEnv }}
+            {{- tpl . $ | nindent 12 }}
+          {{- end }}
+          envFrom:
+            {{- with .Values.extraEnvFrom }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 9000

--- a/charts/webhook-receiver/values.yaml
+++ b/charts/webhook-receiver/values.yaml
@@ -69,14 +69,20 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-livenessProbe:
-  httpGet:
-    path: /hooks/status
-    port: http
-readinessProbe:
-  httpGet:
-    path: /hooks/status
-    port: http
+livenessProbe: {}
+# You should use only one of these two options
+#  httpGet:
+#    path: /hooks/status
+#    port: http
+#  tcpSocket:
+#    port: http
+readinessProbe: {}
+# You should use only one of these two options
+#  httpGet:
+#    path: /hooks/status
+#    port: http
+#  tcpSocket:
+#    port: http
 
 nodeSelector: {}
 

--- a/charts/webhook-receiver/values.yaml
+++ b/charts/webhook-receiver/values.yaml
@@ -93,6 +93,17 @@ affinity: {}
 # Use this to insert env values into the deployment
 env: {}
 
+# Additional environment variables beyond key=value
+extraEnv: ""
+#extraEnv: |
+#  - name: CMD_USER
+#    valueFrom:
+#      secretKeyRef:
+#        name: command-creds
+#        key: username
+# Additional environment variables mapped from Secret or ConfigMap
+extraEnvFrom: ""
+
 hooks:
   webhook1:
     enable: true


### PR DESCRIPTION
With the earlier approach, where the default values activated the `httpGet` probe type, it was not possible to use another probe like `tcpSocket`.

Right now it's on your own to decide how to define your probes. As this is changing the probes by default this means this is a breaking change.
 
## Description
Probes are disabled by default, example is provided in the `values.yaml` file instead.
## Motivation and Context
I saw that with the previous version I wasn't able to disable the `httpGet`probe, even trying to put it to `null` in the subchart where I'm using this chart.

## How Has This Been Tested?
Already tested in production

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contribution guide](https://geek-cookbook.funkypenguin.co.nz/community/contribute/#contributing-recipes)
- [x] The format of my change matches that of existing code/documentation