### PR TITLE
Add extraEnv & extraEnvFrom value for env config beyond key=value pairs, e.g. secrets

### DIFF
--- a/charts/webhook-receiver/templates/deployment.yaml
+++ b/charts/webhook-receiver/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
           - name: {{ $pkey }}
             value: {{ quote $pval }}
           {{- end }}
+          {{- with .Values.extraEnv }}
+          {{- tpl . $ | nindent 12 }}
+          {{- end }}
           envFrom:
             {{- with .Values.extraEnvFrom }}
             {{- tpl . $ | nindent 12 }}

--- a/charts/webhook-receiver/templates/deployment.yaml
+++ b/charts/webhook-receiver/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
           - name: {{ $pkey }}
             value: {{ quote $pval }}
           {{- end }}
+          envFrom:
+            {{- with .Values.extraEnvFrom }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
               containerPort: 9000

--- a/charts/webhook-receiver/values.yaml
+++ b/charts/webhook-receiver/values.yaml
@@ -86,6 +86,14 @@ affinity: {}
 
 # Use this to insert env values into the deployment
 env: {}
+# Additional environment variables mapped from Secret or ConfigMap
+extraEnvFrom: ""
+# - name: CMD_USER
+#   valueFrom:
+#     secretKeyRef:
+#       name: command-creds
+#       key: username
+
 
 hooks:
   webhook1:

--- a/charts/webhook-receiver/values.yaml
+++ b/charts/webhook-receiver/values.yaml
@@ -86,14 +86,15 @@ affinity: {}
 
 # Use this to insert env values into the deployment
 env: {}
-# Additional environment variables mapped from Secret or ConfigMap
-extraEnvFrom: ""
+# Additional environment variables beyond key=value
+extraEnv: ""
 # - name: CMD_USER
 #   valueFrom:
 #     secretKeyRef:
 #       name: command-creds
 #       key: username
-
+# Additional environment variables mapped from Secret or ConfigMap
+extraEnvFrom: ""
 
 hooks:
   webhook1:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above ^^^ -->

## Description
This adds extraEnv & extraEnvFrom to the chart values for env config beyond key=value pairs, e.g. a secret or configmap.

```yaml
extraEnv: |
  - name: SERVICE_USER
    valueFrom:
      secretKeyRef:
        name: webhook-cmd-creds
        key: username
  - name: SERVICE_PASSWORD
    valueFrom:
      secretKeyRef:
        name: webhook-cmd-creds
        key: password
extraEnvFrom: |
  - configMapRef:
      name: cmd-config
```

## Motivation and Context
I need credentials in my command which I want to pass via env vars like ${SERVICE_PASSWORD}.
The current implementation of env with strict key=value doesn't allow for valueFrom.secretKeyRef etc.

## How Has This Been Tested?
Deployed to a private k8s cluster from a private helm repo.
Since the default values are set empty there are no compatibility issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [contribution guide](https://geek-cookbook.funkypenguin.co.nz/community/contribute/#contributing-recipes)
- [x] The format of my change matches that of existing code/documentation